### PR TITLE
Create folder for mvvm

### DIFF
--- a/AluMeet/AluMeet.csproj
+++ b/AluMeet/AluMeet.csproj
@@ -30,6 +30,9 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0-ios|AnyCPU'">
+	  <CreatePackage>false</CreatePackage>
+	</PropertyGroup>
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
@@ -48,4 +51,16 @@
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <None Remove="Model\" />
+	  <None Remove="ViewModels\" />
+	  <None Remove="Views\" />
+	  <None Remove="Services\" />
+	</ItemGroup>
+	<ItemGroup>
+	  <Folder Include="Model\" />
+	  <Folder Include="ViewModels\" />
+	  <Folder Include="Views\" />
+	  <Folder Include="Services\" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
Create different folders to work according to the MVVM architecture. Model folder is created to store the classes and data structures that represent the application's data and business logic. View folder is created to store the user interface components, such as XAML files or code-behind files, responsible for displaying the application's visual elements to the user. ViewModel folder is created to store the classes that act as intermediate between the model and the view in the MVVM architecture. Services folder is created to store the classes that provide additional functionality to the application, such as data access, web services, or other external integration